### PR TITLE
添加依赖/添加日志重试

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ whl\Polygon3-3.0.9-cp311-cp311-win_amd64.whl
 cnocr>=2.2.2.3
 docopt
 httpx
+httpx_socks
 loguru
 opencv_contrib_python
 opencv_python

--- a/utils/config.py
+++ b/utils/config.py
@@ -66,8 +66,13 @@ def modify_json_file(filename: str, key, value):
     # 先读，再写
     data, file_path = read_json_file(filename, path=True)
     data[key] = value
-    with open(file_path, "wb") as f:
-        f.write(orjson.dumps(data, option=orjson.OPT_PASSTHROUGH_DATETIME | orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_INDENT_2))
+    try:
+        with open(file_path, "wb") as f:
+            f.write(orjson.dumps(data, option=orjson.OPT_PASSTHROUGH_DATETIME | orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_INDENT_2))
+    except PermissionError as e:
+        import time
+        time.sleep(1)
+        modify_json_file(filename, key, value)
 
 
 def get_file(path, exclude=[], exclude_file=None, get_path=False, only_place=False) -> list[str]:


### PR DESCRIPTION
Auto_Star_Rail/utils/requests.py:14

添加日志的重试，避免日志文件被一些同步盘扫描占用（该死的onedrive），导致整个进程崩溃